### PR TITLE
Add a warning to CMakeLists.txt if the compiler is BAD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,16 +50,38 @@ endif()
 
 # NVidia
 add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,NVHPC>:-Minform=warn;>")
+add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,NVHPC>:-Mnofpapprox>")
+add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,NVHPC>:-target=multicore;-stdpar=multicore>")
 if (${CMAKE_Fortran_COMPILER_ID} MATCHES "NVHPC")
+  message(WARNING "HOPPET: ${CMAKE_Fortran_COMPILER_ID} compiler might contain bugs that will prevent HOPPET from working  correctly. Please see https://fortran-lang.discourse.group/t/an-interesting-difference-between-compilers/7131 for details")
   set(CMAKE_Fortran_FLAGS_DEBUG  "${CMAKE_Fortran_FLAGS_DEBUG} -g -traceback -Mbounds -Mchkptr")
 endif()
 
-# XL
+# NAG
+add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,NAG>:-dcfuns;-dusty>")
+if (${CMAKE_Fortran_COMPILER_ID} MATCHES "NAG")
+  set(CMAKE_Fortran_FLAGS_DEBUG  "${CMAKE_Fortran_FLAGS_DEBUG} -g -C=all -mtrace -gline")
+endif()
+
+# IBM XL
 add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,XL>:-qfree;-qextname;-qhalt=s>")
 add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,XL>:-qstackprotect=all>")
-
 if (${CMAKE_Fortran_COMPILER_ID} MATCHES "XL")
+  message(WARNING "HOPPET: ${CMAKE_Fortran_COMPILER_ID} compiler might contain bugs that will prevent HOPPET from working  correctly. Please see https://fortran-lang.discourse.group/t/an-interesting-difference-between-compilers/7131 for details")
   set(CMAKE_Fortran_FLAGS_DEBUG  "${CMAKE_Fortran_FLAGS_DEBUG} -g -qcheck -qsigtrap")
+endif()
+
+# AMD Flang
+add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,Flang>:-Wall>")
+if (${CMAKE_Fortran_COMPILER_ID} MATCHES "Flang")
+  message(WARNING "HOPPET: ${CMAKE_Fortran_COMPILER_ID} compiler might contain bugs that will prevent HOPPET from working  correctly. Please see https://fortran-lang.discourse.group/t/an-interesting-difference-between-compilers/7131 for details")
+  set(CMAKE_Fortran_FLAGS_DEBUG  "${CMAKE_Fortran_FLAGS_DEBUG} -g")
+endif()
+
+# ARM 
+if (${CMAKE_Fortran_COMPILER_ID} MATCHES "ARM")
+  message(WARNING "HOPPET: ${CMAKE_Fortran_COMPILER_ID} compiler might contain bugs that will prevent HOPPET from working  correctly. Please see https://fortran-lang.discourse.group/t/an-interesting-difference-between-compilers/7131 for details")
+  set(CMAKE_Fortran_FLAGS_DEBUG  "${CMAKE_Fortran_FLAGS_DEBUG} -g")
 endif()
 
 if (HOPPET_ENABLE_FPES)
@@ -67,7 +89,10 @@ if (HOPPET_ENABLE_FPES)
   add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,Intel>:-fpe0>")
   add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,IntelLLVM>:-fpe0>")
   add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,NVHPC>:-Ktrap=divz,denorm,fp,inexact,inv,ovf,unf>")
+  add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,NAG>:-ieee=stop>")
   add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,XL>:-qflttrap=overflow:underflow:invalid:zerodivide:enable>")
+  add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,Flang>:-ffp-exception-behavior=strict>")
+  add_compile_options("$<$<COMPILE_LANG_AND_ID:Fortran,ARM>:-ffp-contract=on>")
 endif()
 
 

--- a/src/warnings_and_errors.f90
+++ b/src/warnings_and_errors.f90
@@ -133,24 +133,8 @@ contains
     if (present(intval))  write(stddev,*) intval
     if (present(dbleval)) write(stddev,*) dbleval
 
-    ! write(stddev,*)
-    ! write(stddev,'(a)') &
-    !      &'----- Error handler will now attempt to dump core and  stop'
-    ! a = 1.0
-    ! b = 1.0
-    ! write(stddev,*) 1.0/sqrt(a-b)
-    ! !-- in case division by zero didn't solve problem
-    ! !-- works only with lf95? Needs --trace compile-time flag
-    ! !call error('lf95 specific traceback follows:')
-    ! !--
-    ! stop
-    !call error('')
     write(stddev,*)
-    !stop
-    !! NB: this is non-standard, but seems to be supported by gfortran
-    !!     and ifort
-    call exit(1)
-    !call abort
+    stop 1
   end subroutine wae_error
   
   !!


### PR DESCRIPTION
Dear @gavinsalam, in this MR:
- Add a warning to CMakeLists.txt if the compiler is BAD.
-  More compilers
-  Use "stop 1" instead of "exit(1)"
- 