### PR TITLE
Change iflav parameter type from double to int

### DIFF
--- a/src/hoppet.h
+++ b/src/hoppet.h
@@ -389,7 +389,7 @@ extern "C" {
 			const double & Q,
 			const double & muR_in,
 			const double & muF_in,
-			const double & iflav,
+			const int & iflav,
 			double * F);
 
   /// calculate the structure function at x, Q, with muR and muF as


### PR DESCRIPTION
On the fortran side it is an int https://github.com/hoppet-code/hoppet/blob/a7bc48b78c5f21c99d217edba0cd441f0daf59c1/src/structure_functions.f90#L2354
Probably no problem since it just pointers.