### PR TITLE
fix: extend C3SOFT with dummy vars to have matching size common blocks for LTO

### DIFF
--- a/src/exact-coefs/xc3ns2e.f
+++ b/src/exact-coefs/xc3ns2e.f
@@ -23,7 +23,7 @@
       SUBROUTINE SET_C3SOFT(NF)
       IMPLICIT REAL*8 (A - Z)
       INTEGER NF
-      COMMON / C3SOFT / A0, A1, A2, A3
+      COMMON / C3SOFT / A0, A1, A2, A3, A4, A5
       PARAMETER ( Z2 = 1.6449 34066 84822 64365 D0,
      ,     Z3 = 1.2020 56903 15959 42854 D0 )
 *     
@@ -77,7 +77,7 @@
 *
 * ..The soft coefficients for use in X2NP2B and X2NP2C
 *
-       COMMON / C3SOFT / A0, A1, A2, A3
+       COMMON / C3SOFT / A0, A1, A2, A3, A4, A5
 *
 * ...Colour factors
 *
@@ -182,7 +182,7 @@ c     c3qq2 = nf*cf * (  - 116.D0/27.D0 - 302.D0/27.D0*x + 247.D
        IMPLICIT REAL*8 (A - Z)
        INTEGER NF
 *
-       COMMON / C3SOFT / A0, A1, A2, A3
+       COMMON / C3SOFT / A0, A1, A2, A3, A4, A5
 *
        DL1 = LOG (1.D0-Y)
        DM  = 1.D0/(1.D0-Y)
@@ -204,7 +204,7 @@ c     c3qq2 = nf*cf * (  - 116.D0/27.D0 - 302.D0/27.D0*x + 247.D
        PARAMETER ( Z2 = 1.6449 34066 84822 64365 D0,
      ,             Z3 = 1.2020 56903 15959 42854 D0 )
 *
-       COMMON / C3SOFT / A0, A1, A2, A3
+       COMMON / C3SOFT / A0, A1, A2, A3, A4, A5
 *
 * ...Colour factors
 *


### PR DESCRIPTION
The fix of https://github.com/hoppet-code/hoppet/issues/33 in https://github.com/hoppet-code/hoppet/commit/7d383e569f0ddffe10df9d906cca2cc26e7e9a54 did not work for me, since there are still `C3SOFT`s, with different dimensions.

To obtain the error I set some strict compiler options (gcc/gfortran on linux):

```bash
cmake -B build -S . \
      -DHOPPET_USE_EXACT_COEF=ON \
      -DCMAKE_C_FLAGS="-flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing" \
      -DCMAKE_CXX_FLAGS="-flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing" \
      -DCMAKE_Fortran_FLAGS="-flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
```
There are more nitpick-errors related to boolean conversion which I hope to send patches for soon too (see https://github.com/hoppet-code/hoppet/blob/a7bc48b78c5f21c99d217edba0cd441f0daf59c1/src/hoppet.h#L139-L140).

If this gets merged renaming to `C3SOFT` to `C3SOFTN3LO` in https://github.com/hoppet-code/hoppet/commit/7d383e569f0ddffe10df9d906cca2cc26e7e9a54 could also be reverted.

Cheers,
APN