### PR TITLE
hoppetStrFctNoMuFlav missing integer iflav argument

### DIFF
--- a/src/hoppet.h
+++ b/src/hoppet.h
@@ -396,7 +396,7 @@ extern "C" {
   /// requested in hoppetStartStrFct. This is the sum over all orders
   void hoppetStrFctNoMuFlav(const double & x,
 			    const double & Q,
-			    const double & iflav,
+			    const int & iflav,
 			    double * F);
 
   /// F_LO

--- a/src/structure_functions.f90
+++ b/src/structure_functions.f90
@@ -2386,9 +2386,10 @@ end subroutine hoppetStrFctNoMu
 !! @param[in]       iflav      parton flavour
 !! @return          an array of all structure functions summed over orders decomposed in flavour
 !!
-subroutine hoppetStrFctNoMuFlav(x, Q, res) 
+subroutine hoppetStrFctNoMuFlav(x, Q, iflav, res)
   use streamlined_interface; use structure_functions
   real(dp) :: x, Q
+  integer :: iflav
   real(dp) :: res(1:3)
   
   res = StrFct_flav(x, Q, iflav = iflav)


### PR DESCRIPTION
I am not sure why this did not give an error before, probably optimized away and/or never used. I assume the documentation of the function mentioning `iflav` as input and the function using `iflav` suggests it should be a parameter of the function?